### PR TITLE
Generate test result from cargo test

### DIFF
--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -11,6 +11,14 @@ from colcon_core.shell import get_command_environment
 from colcon_core.task import check_call
 from colcon_core.task import TaskExtensionPoint
 
+from colcon_core.event.command import Command
+from colcon_core.event.command import CommandEnded
+from colcon_core.event.output import StderrLine
+from colcon_core.event.output import StdoutLine
+from colcon_core.subprocess import run
+from xml.etree.ElementTree import Element, SubElement, ElementTree
+import json
+
 logger = colcon_logger.getChild(__name__)
 
 
@@ -47,13 +55,86 @@ class CargoTestTask(TaskExtensionPoint):
             raise RuntimeError("Could not find 'cargo' executable")
 
         # invoke cargo test
-        rc = await check_call(
+        rc, stdout = await check_call_return_stdout(
             self.context,
             [CARGO_EXECUTABLE, 'test', '-q',
-                '--target-dir', test_results_path],
-            cwd=args.path, env=env)
+             '--target-dir', test_results_path,
+             '--', '-Z', 'unstable-options', '--format=json'
+             ],
+            cwd=args.path, env=env, use_pty=True)
+
+        cargo_json_to_xml(stdout, test_results_path + '/tests_report.xml')
 
         if rc.returncode:
             self.context.put_event_into_queue(TestFailure(pkg.name))
             # the return code should still be 0
         return 0
+
+
+def cargo_json_to_xml(stdout, output_filename):
+    root = Element('testsuites')
+    testsuite = None
+    total_tests = 0
+    total_failures = 0
+    for line in stdout:
+        obj = json.loads(line)
+        if obj['type'] == 'suite':
+            if obj['event'] == 'started':
+                testsuite = SubElement(root, 'testsuite')
+                testsuite.set('tests', str(obj['test_count']))
+                total_tests += int(obj['test_count'])
+            else:
+                if testsuite is not None:
+                    testsuite.set('failures', str(obj['failed']))
+                    total_failures += int(obj['failed'])
+        if testsuite is not None:
+            if obj['type'] == 'test':
+                if obj['event'] == 'ok':
+                    SubElement(testsuite, 'testcase', {'name': obj['name']})
+                elif obj['event'] == 'failed':
+                    test = SubElement(testsuite, 'testcase', {'name': obj['name']})
+                    f = SubElement(test, 'failure')
+                    f.text = obj['stdout']
+
+    root.set('tests', str(total_tests))
+    root.set('failures', str(total_failures))
+    et = ElementTree(root)
+    et.write(output_filename)
+
+
+async def check_call_return_stdout(
+        context, cmd, *, cwd=None, env=None, shell=False, use_pty=None
+):
+    """
+    Run the command described by cmd.
+
+    Post a `Command` event to the queue describing the exact invocation in
+    order to allow reproducing it.
+    All output to `stdout` and `stderr` is posted as `StdoutLine` and
+    `StderrLine` events to the event queue.
+
+    :param cmd: The command and its arguments
+    :param cwd: the working directory for the subprocess
+    :param env: a dictionary with environment variables
+    :param shell: whether to use the shell as the program to execute
+    :param use_pty: whether to use a pseudo terminal
+    :returns: the result of the completed process and aggregated stdout
+    """
+    stdout = []
+
+    def stdout_callback(line):
+        context.put_event_into_queue(StdoutLine(line))
+        stdout.append(line)
+
+    def stderr_callback(line):
+        context.put_event_into_queue(StderrLine(line))
+
+    context.put_event_into_queue(
+        Command(cmd, cwd=cwd, env=env, shell=shell))
+    rc = await run(
+        cmd, stdout_callback, stderr_callback,
+        cwd=cwd, env=env, shell=shell, use_pty=use_pty)
+    context.put_event_into_queue(
+        CommandEnded(
+            cmd, cwd=cwd, env=env, shell=shell, returncode=rc.returncode))
+    return rc, stdout


### PR DESCRIPTION
ref #3 

Generate xml from captured stdout of cargo-test. 

I did not find a way how to get captured stdout from colcon. Therefore, I implemented function *check_call_return_stdout* as an alternative to *check_call*. I would prefer a better solution for obtaining stdout - is there another way how to get captured stdout in colcon?