### PR TITLE
Replace deprecated calls to check_call() with run()

### DIFF
--- a/colcon_cargo/__init__.py
+++ b/colcon_cargo/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Easymov Robotics
 # Licensed under the Apache License, Version 2.0
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -9,7 +9,7 @@ from colcon_core.environment import create_environment_scripts
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import create_environment_hook, get_command_environment
-from colcon_core.task import check_call
+from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 
 logger = colcon_logger.getChild(__name__)
@@ -78,5 +78,5 @@ class CargoBuildTask(TaskExtensionPoint):
             '--path', args.path,
             '--root', root_dir]
 
-        return await check_call(
+        return await run(
             self.context, cmd, cwd=args.build_base, env=env)

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -8,7 +8,7 @@ from colcon_core.event.test import TestFailure
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import get_command_environment
-from colcon_core.task import check_call
+from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 
 logger = colcon_logger.getChild(__name__)
@@ -47,7 +47,7 @@ class CargoTestTask(TaskExtensionPoint):
             raise RuntimeError("Could not find 'cargo' executable")
 
         # invoke cargo test
-        rc = await check_call(
+        rc = await run(
             self.context,
             [CARGO_EXECUTABLE, 'test', '-q',
                 '--target-dir', test_results_path],


### PR DESCRIPTION
When using `colcon build` or `colcon test` on a Cargo project, the user gets the following message.

> /usr/local/lib/python3.6/dist-packages/colcon_cargo-0.1.1-py3.6.egg/colcon_cargo/task/cargo/test.py:54: UserWarning: colcon_core.task.check_call() has been deprecated, use colcon_core.task.run() instead

This pull request aims to change this call from `check_call()` to `run()` in order to suppress this message. Besides that, the version number is increase from v0.1.1 to v0.1.2.