### PR TITLE
Fix extract-data logic - return when TOML decoding fails

### DIFF
--- a/colcon_cargo/package_identification/cargo.py
+++ b/colcon_cargo/package_identification/cargo.py
@@ -1,10 +1,13 @@
 # Copyright 2018 Easymov Robotics
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.logging import colcon_logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
 from colcon_core.plugin_system import satisfies_version
 import toml
+
+logger = colcon_logger.getChild(__name__)
 
 
 class CargoPackageIdentification(PackageIdentificationExtensionPoint):
@@ -25,9 +28,10 @@ class CargoPackageIdentification(PackageIdentificationExtensionPoint):
             return
 
         data = extract_data(cargo_toml)
-        if not data['name'] and not metadata.name:
+        if not data:
             raise RuntimeError(
-                "Failed to extract project name from '%s'" % cargo_toml)
+                'Failed to extract Rust package information from "%s"'
+                % cargo_toml.absolute())
 
         metadata.type = 'cargo'
         if metadata.name is None:
@@ -44,17 +48,18 @@ def extract_data(cargo_toml):
     :rtype: dict
     """
     content = {}
-
     try:
         content = toml.load(str(cargo_toml))
-        data = {}
-        data['name'] = extract_project_name(content)
     except toml.TomlDecodeError:
-        pass
+        logger.error('Decoding error when processing "%s"'
+                     % cargo_toml.absolute())
+        return
 
-    # fall back to use the directory name
-    if data['name'] is None:
-        data['name'] = cargo_toml.parent.name
+    # set the project name - fall back to use the directory name
+    data = {}
+    toml_name_attr = extract_project_name(content)
+    data['name'] = toml_name_attr if toml_name_attr is not None else \
+        cargo_toml.parent.name
 
     depends = extract_dependencies(content)
     # exclude self references


### PR DESCRIPTION
Currently in `extract_data` if `toml.load` fails data is unset. Hence
subsequent calls to data['name'] will fail. The correct approach is to
return immediately in such cases.

Also TomlDecodeError may be triggered due to `toml.load`, so that's the
only directive that must be wrapped in a `try-except` statement.