### PR TITLE
Reduce duplication between colcon-cargo and colcon-ros-cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ An extension for [colcon-core](https://github.com/colcon/colcon-core) to
 support Rust projects built with Cargo.
 
 ## Install
-
-`pip3 install --user --upgrade git+https://github.com/colcon/colcon-cargo.git`
+```sh
+$ pip3 install --user --upgrade git+https://github.com/colcon/colcon-cargo.git
+```
 
 ## Usage / Minimal example
 
@@ -38,7 +39,7 @@ $ tree .
 
 </details>
 
-Verify that cargo detects the rust packages:
+Verify that cargo detects the Rust packages:
 
 ```sh
 $ colcon list
@@ -47,7 +48,7 @@ hello-world     hello-world     (cargo)
 hello-world2    hello-world2    (cargo)
 ```
 
-Build them with cargo:
+Build them with Cargo:
 
 ```sh
 $ colcon build
@@ -58,8 +59,6 @@ Finished <<< hello_world_2 [1.84s]
 Finished <<< hello_world [1.94s]
 
 Summary: 2 packages finished [2.34s]
-
-# source and run the executables.
 ```
 
 Source the generated `install/` directory and execute:

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -1,8 +1,8 @@
 # Copyright 2018 Easymov Robotics
 # Licensed under the Apache License, Version 2.0
 
-import os
 from pathlib import Path
+import shutil
 
 from colcon_cargo.task.cargo import CARGO_EXECUTABLE
 from colcon_core.environment import create_environment_scripts
@@ -29,11 +29,16 @@ class CargoBuildTask(TaskExtensionPoint):
             help='Pass arguments to Cargo projects. '
             'Arguments matching other options must be prefixed by a space,\n'
             'e.g. --cargo-args " --help"')
+        parser.add_argument(
+            '--clean-build',
+            action='store_true',
+            help='Remove old build dir before the build.')
 
     async def build(  # noqa: D102
-        self, *, additional_hooks=[], skip_hook_creation=False
+        self, *, additional_hooks=None, skip_hook_creation=False
     ):
-        pkg = self.context.pkg
+        if additional_hooks is None:
+            additional_hooks = []
         args = self.context.args
 
         logger.info(
@@ -46,37 +51,55 @@ class CargoBuildTask(TaskExtensionPoint):
             logger.error(str(e))
             return 1
 
-        rc = await self._build(args, env)
+        self.progress('prepare')
+        rc = self._prepare(env, additional_hooks)
+        if rc:
+            return rc
+
+        # Clean up the build dir
+        build_dir = Path(args.build_base)
+        if args.clean_build:
+            if build_dir.is_symlink():
+                build_dir.unlink()
+            elif build_dir.exists():
+                shutil.rmtree(build_dir)
+
+        # Invoke build step
+        if CARGO_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'cargo' executable")
+
+        cargo_args = args.cargo_args
+        if cargo_args is None:
+            cargo_args = []
+        cmd = self._build_cmd(cargo_args)
+
+        self.progress('build')
+
+        rc = await run(
+            self.context, cmd, cwd=self.context.pkg.path, env=env)
         if rc and rc.returncode:
             return rc.returncode
 
-        additional_hooks += create_environment_hook(
-            'cargo_{}_path'.format(pkg.name),
-            Path(args.install_base), pkg.name,
-            'PATH', os.path.join('lib', self.context.pkg.name, 'bin'),
-            mode='prepend')
-
         if not skip_hook_creation:
             create_environment_scripts(
-                pkg, args, additional_hooks=additional_hooks)
+                self.context.pkg, args, additional_hooks=additional_hooks)
 
-    async def _build(self, args, env):
-        self.progress('build')
+    # Overridden by colcon-ros-cargo
+    def _prepare(self, env, additional_hooks):
+        pkg = self.context.pkg
+        additional_hooks += create_environment_hook(
+            'cargo_{}_path'.format(pkg.name),
+            Path(self.context.args.install_base), pkg.name,
+            'PATH', 'bin'
+        )
 
-        os.makedirs(args.build_base, exist_ok=True)
-
-        env['CARGO_TARGET_DIR'] = args.build_base
-
-        root_dir = os.path.join(
-            args.install_base, 'lib', self.context.pkg.name)
-
-        # invoke build step
-        if CARGO_EXECUTABLE is None:
-            raise RuntimeError("Could not find 'cargo' executable")
-        cmd = [
-            CARGO_EXECUTABLE, 'install', '--force', '-q',
+    # Overridden by colcon-ros-cargo
+    def _build_cmd(self, cargo_args):
+        args = self.context.args
+        return [
+            CARGO_EXECUTABLE, 'install',
+            '--force',
+            '--quiet',
             '--path', args.path,
-            '--root', root_dir]
-
-        return await run(
-            self.context, cmd, cwd=args.build_base, env=env)
+            '--root', args.install_base,
+        ] + cargo_args


### PR DESCRIPTION
This tries to make colcon-cargo a better base class for colcon-ros-cargo, so that both packages have fewer combined lines.

As a concrete benefit, colcon-cargo now supports cleaning up the build directory.

I changed the installation location for binaries to be `${prefix}/bin`, since I think that's a more standard location.