### PR TITLE
Suppress pkg_resources deprecation in flake8_import_order

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ filterwarnings =
     error
     # Suppress deprecation warnings in other packages
     ignore:lib2to3 package is deprecated::scspell
+    ignore:pkg_resources is deprecated as an API::flake8_import_order
     ignore:SelectableGroups dict interface is deprecated::flake8
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pyreadline
     ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning


### PR DESCRIPTION
This change has already been applied to other colcon packages.