### PR TITLE
Fix README.md reference from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,8 @@ classifiers =
     Topic :: Software Development :: Build Tools
 license = Apache License, Version 2.0
 description = Extension for colcon to support cargo packages.
-long_description = file: README.rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = colcon
 
 [options]


### PR DESCRIPTION
It appears that the package authors preferred markdown over rst, but didn't change the setup.cfg when it was copied from another colcon project.

Should resolve:
```
SetuptoolsWarning: File 'src/colcon-cargo/README.rst' cannot be found
  return '\n'.join(
```