### PR TITLE
ignore cmake projects

### DIFF
--- a/colcon_cargo/package_identification/cargo.py
+++ b/colcon_cargo/package_identification/cargo.py
@@ -23,6 +23,10 @@ class CargoPackageIdentification(PackageIdentificationExtensionPoint):
     def identify(self, metadata):  # noqa: D102
         if metadata.type is not None and metadata.type != 'cargo':
             return
+        
+        cmakelists = metadata.path / 'CMakeLists.txt'
+        if cmakelists.is_file():
+            return
 
         cargo_toml = metadata.path / 'Cargo.toml'
         if not cargo_toml.is_file():


### PR DESCRIPTION
The r2r project still uses CMake for building the nodes in the minimal node example. This PR ignores packages containing `CMakeLists.txt` to allow both libraries to be used for writing ROS nodes.

The plugin still can compile the r2r node but it leads to problems as described [here](https://github.com/m-dahl/r2r_minimal_node/issues/8). I don't really understand the need for colcon-cargo and colcon-ros-cargo at the same time as described in the ros2_rust Readme so I did the PR at both repositories. It seems like the relevant plugin for my system is colcon-ros-cargo though.