### PR TITLE
Fix package dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,16 +24,7 @@ keywords = colcon
 [options]
 python_requires = >=3.6
 install_requires =
-  catkin_pkg>=0.4.14
-  colcon-cmake>=0.2.6
-  colcon-core>=0.7.0
-  # technically not a required dependency but "very common" for ROS 1 users
-  colcon-pkg-config
-  colcon-python-setup-py>=0.2.4
-  # technically not a required dependency but "very common" for ROS users
-  colcon-recursive-crawl
-  # to set an environment variable when a package installs a library
-  colcon-library-path
+  colcon-core
   toml
 packages = find:
 zip_safe = true

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-cargo]
 No-Python2:
-Depends3: python3-colcon-core, python3-colcon-library-path python3-toml
+Depends3: python3-colcon-core, python3-toml
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
1. The vast majority of these dependencies were copy/pasted from colcon-ros and aren't needed for colcon-cargo
2. The syntax in the stdeb.cfg wasn't correct