### PR TITLE
Add support for cargo test

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,27 @@ $ hello-world2
 Hello, world!
 ```
 
+### Testing
+
+Test the packages with cargo:
+
+```sh
+$ colcon test
+Starting >>> hello_worl2
+Starting >>> hello_world
+Finished <<< hello_world [0.24s]                                           
+Finished <<< hello_worl2 [0.25s]
+
+Summary: 2 packages finished [0.39s]
+```
+
+Inspect the test results (`cargo test` and `cargo fmt --check`).
+They should all succeed for the empty templates:
+
+```sh
+$ colcon test-result --all
+build/hello_worl2/cargo_test.xml: 2 tests, 0 errors, 0 failures, 0 skipped
+build/hello_world/cargo_test.xml: 2 tests, 0 errors, 0 failures, 0 skipped
+
+Summary: 4 tests, 0 errors, 0 failures, 0 skipped
+```

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Test the packages with cargo:
 
 ```sh
 $ colcon test
-Starting >>> hello_worl2
+Starting >>> hello_world_2
 Starting >>> hello_world
 Finished <<< hello_world [0.24s]                                           
-Finished <<< hello_worl2 [0.25s]
+Finished <<< hello_world_2 [0.25s]
 
 Summary: 2 packages finished [0.39s]
 ```
@@ -93,7 +93,7 @@ They should all succeed for the empty templates:
 
 ```sh
 $ colcon test-result --all
-build/hello_worl2/cargo_test.xml: 2 tests, 0 errors, 0 failures, 0 skipped
+build/hello_world_2/cargo_test.xml: 2 tests, 0 errors, 0 failures, 0 skipped
 build/hello_world/cargo_test.xml: 2 tests, 0 errors, 0 failures, 0 skipped
 
 Summary: 4 tests, 0 errors, 0 failures, 0 skipped

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -112,7 +112,6 @@ class CargoBuildTask(TaskExtensionPoint):
             CARGO_EXECUTABLE,
             'build',
             '--quiet',
-            '--manifest-path', args.path + '/Cargo.toml',
             '--target-dir', args.build_base,
             '--all-targets',
         ] + cargo_args
@@ -126,6 +125,6 @@ class CargoBuildTask(TaskExtensionPoint):
             '--force',
             '--quiet',
             '--locked',
-            '--path', args.path,
+            '--path', '.',
             '--root', args.install_base,
         ] + cargo_args

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -125,6 +125,7 @@ class CargoBuildTask(TaskExtensionPoint):
             'install',
             '--force',
             '--quiet',
+            '--locked',
             '--path', args.path,
             '--root', args.install_base,
         ] + cargo_args

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -112,9 +112,6 @@ class CargoBuildTask(TaskExtensionPoint):
             'build',
             '--quiet',
             '--target-dir', args.build_base,
-            '--bins',
-            '--lib',
-            '--tests',
         ] + cargo_args
 
     # Overridden by colcon-ros-cargo

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -97,9 +97,12 @@ class CargoBuildTask(TaskExtensionPoint):
     def _build_cmd(self, cargo_args):
         args = self.context.args
         return [
-            CARGO_EXECUTABLE, 'install',
-            '--force',
+            CARGO_EXECUTABLE,
+            'build',
             '--quiet',
-            '--path', args.path,
-            '--root', args.install_base,
+            '--manifest-path', args.path + '/Cargo.toml',
+            '--target-dir', args.install_base,
+            '--bins',
+            '--lib',
+            '--tests',
         ] + cargo_args

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -84,10 +84,12 @@ class CargoBuildTask(TaskExtensionPoint):
 
         self.progress('install')
 
-        rc = await run(
-            self.context, cmd, cwd=self.context.pkg.path, env=env)
-        if rc and rc.returncode:
-            return rc.returncode
+        # colcon-ros-cargo overrides install command to return None
+        if cmd is not None:
+            rc = await run(
+                self.context, cmd, cwd=self.context.pkg.path, env=env)
+            if rc and rc.returncode:
+                return rc.returncode
 
         if not skip_hook_creation:
             create_environment_scripts(

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -107,13 +107,14 @@ class CargoBuildTask(TaskExtensionPoint):
     # Overridden by colcon-ros-cargo
     def _build_cmd(self, cargo_args):
         args = self.context.args
-        # TODO(luca) Check if we can avoid all-targets to save space
         return [
             CARGO_EXECUTABLE,
             'build',
             '--quiet',
             '--target-dir', args.build_base,
-            '--all-targets',
+            '--bins',
+            '--lib',
+            '--tests',
         ] + cargo_args
 
     # Overridden by colcon-ros-cargo

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -32,6 +32,17 @@ class CargoTestTask(TaskExtensionPoint):
             'e.g. --cargo-args " --help"')
 
     async def test(self, *, additional_hooks=None):  # noqa: D102
+        """
+        Runs tests and style checks for the requested package.
+
+        Results are compiled into a single result `cargo_test.xml` file
+        with two test results, one for all the tests (cargo test) and one for
+        style (`cargo fmt --check`).
+        Documentation tests (`cargo test --doc`) are not implemented
+        since it is not possible to distinguish between a test that failed
+        because of a failing case and one that failed because the crate
+        contains no library target.
+        """
         pkg = self.context.pkg
         args = self.context.args
 

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -38,7 +38,8 @@ class CargoTestTask(TaskExtensionPoint):
         logger.info(
             "Testing Cargo package in '{args.path}'".format_map(locals()))
 
-        assert os.path.exists(args.build_base)
+        assert os.path.exists(args.build_base), \
+            'Has this package been built before?'
 
         test_results_path = os.path.join(args.build_base, 'cargo_test.xml')
 

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -96,7 +96,7 @@ class CargoTestTask(TaskExtensionPoint):
             'test',
             '--quiet',
             '--target-dir',
-            args.build_base,
+            args.install_base,
         ] + cargo_args + [
             '--',
             '--color=never',
@@ -109,7 +109,7 @@ class CargoTestTask(TaskExtensionPoint):
             'test',
             '--quiet',
             '--target-dir',
-            args.build_base,
+            args.install_base,
             '--doc',
         ] + cargo_args + [
             '--',

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -50,6 +50,9 @@ class CargoTestTask(TaskExtensionPoint):
             logger.error(str(e))
             return 1
 
+        # Disable color to avoid escape sequences in test result file
+        env['NO_COLOR'] = '1'
+
         if CARGO_EXECUTABLE is None:
             # TODO(luca) log this as error in the test result file
             raise RuntimeError("Could not find 'cargo' executable")
@@ -94,6 +97,8 @@ class CargoTestTask(TaskExtensionPoint):
             '--quiet',
             '--target-dir',
             args.build_base,
+            '--',
+            '--color=never',
         ] + cargo_args
 
     def _doc_test_cmd(self, cargo_args):
@@ -105,6 +110,8 @@ class CargoTestTask(TaskExtensionPoint):
             '--target-dir',
             args.build_base,
             '--doc',
+            '--',
+            '--color=never',
         ] + cargo_args
 
     def _fmt_cmd(self, cargo_args):
@@ -112,6 +119,8 @@ class CargoTestTask(TaskExtensionPoint):
             CARGO_EXECUTABLE,
             'fmt',
             '--check',
+            '--',
+            '--color=never',
         ] + cargo_args
 
     def _create_error_report(self, unit_rc, doc_rc, fmt_rc) -> eTree.Element:

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -63,7 +63,6 @@ class CargoTestTask(TaskExtensionPoint):
             return 1
 
         if CARGO_EXECUTABLE is None:
-            # TODO(luca) log this as error in the test result file
             raise RuntimeError("Could not find 'cargo' executable")
 
         cargo_args = args.cargo_args

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -38,8 +38,6 @@ class CargoTestTask(TaskExtensionPoint):
         logger.info(
             "Testing Cargo package in '{args.path}'".format_map(locals()))
 
-        assert os.path.exists(args.build_base)
-
         test_results_path = os.path.join(args.build_base, 'cargo_test.xml')
 
         try:

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -67,8 +67,7 @@ class CargoTestTask(TaskExtensionPoint):
 
         if CARGO_EXECUTABLE is None:
             # TODO(luca) log this as error in the test result file
-            logger.error("Could not find 'cargo' executable")
-            return 1
+            raise RuntimeError("Could not find 'cargo' executable")
 
         cargo_args = args.cargo_args
         if cargo_args is None:

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -96,7 +96,7 @@ class CargoTestTask(TaskExtensionPoint):
             'test',
             '--quiet',
             '--target-dir',
-            args.install_base,
+            args.build_base,
         ] + cargo_args + [
             '--',
             '--color=never',
@@ -109,7 +109,7 @@ class CargoTestTask(TaskExtensionPoint):
             'test',
             '--quiet',
             '--target-dir',
-            args.install_base,
+            args.build_base,
             '--doc',
         ] + cargo_args + [
             '--',

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+from xml.dom import minidom
 import xml.etree.ElementTree as eTree
 
 from colcon_cargo.task.cargo import CARGO_EXECUTABLE
@@ -70,9 +71,10 @@ class CargoTestTask(TaskExtensionPoint):
 
         error_report = self._create_error_report(unit_rc, doc_rc, fmt_rc)
         with open(test_results_path, 'wb') as result_file:
-            tree = eTree.ElementTree(error_report)
-            eTree.indent(tree)
-            tree.write(result_file, encoding='utf-8', xml_declaration=True)
+            xmlstr = minidom.parseString(eTree.tostring(error_report))
+            xmlstr = xmlstr.toprettyxml(indent='    ',
+                                        encoding='utf-8', standalone=True)
+            result_file.write(xmlstr)
 
         if unit_rc.returncode or doc_rc.returncode or fmt_rc.returncode:
             self.context.put_event_into_queue(TestFailure(pkg.name))

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -74,7 +74,7 @@ class CargoTestTask(TaskExtensionPoint):
 
         fmt_rc = await run(
             self.context,
-            self._fmt_cmd(cargo_args),
+            self._fmt_cmd(),
             cwd=args.path, env=env, capture_output=True)
 
         error_report = self._create_error_report(unit_rc, doc_rc, fmt_rc)
@@ -97,9 +97,10 @@ class CargoTestTask(TaskExtensionPoint):
             '--quiet',
             '--target-dir',
             args.build_base,
+        ] + cargo_args + [
             '--',
             '--color=never',
-        ] + cargo_args
+        ]
 
     def _doc_test_cmd(self, cargo_args):
         args = self.context.args
@@ -110,18 +111,20 @@ class CargoTestTask(TaskExtensionPoint):
             '--target-dir',
             args.build_base,
             '--doc',
+        ] + cargo_args + [
             '--',
             '--color=never',
-        ] + cargo_args
+        ]
 
-    def _fmt_cmd(self, cargo_args):
+    # Ignore cargo args for rustfmt
+    def _fmt_cmd(self):
         return [
             CARGO_EXECUTABLE,
             'fmt',
             '--check',
             '--',
             '--color=never',
-        ] + cargo_args
+        ]
 
     def _create_error_report(self, unit_rc, doc_rc, fmt_rc) -> eTree.Element:
         # TODO(luca) revisit when programmatic output from cargo test is

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -24,7 +24,12 @@ class CargoTestTask(TaskExtensionPoint):
         satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
     def add_arguments(self, *, parser):  # noqa: D102
-        pass
+        parser.add_argument(
+            '--cargo-args',
+            nargs='*', metavar='*', type=str.lstrip,
+            help='Pass arguments to Cargo projects. '
+            'Arguments matching other options must be prefixed by a space,\n'
+            'e.g. --cargo-args " --help"')
 
     async def test(self, *, additional_hooks=None):  # noqa: D102
         pkg = self.context.pkg

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -72,8 +72,7 @@ class CargoTestTask(TaskExtensionPoint):
         error_report = self._create_error_report(unit_rc, doc_rc, fmt_rc)
         with open(test_results_path, 'wb') as result_file:
             xmlstr = minidom.parseString(eTree.tostring(error_report))
-            xmlstr = xmlstr.toprettyxml(indent='    ',
-                                        encoding='utf-8', standalone=True)
+            xmlstr = xmlstr.toprettyxml(indent='    ', encoding='utf-8')
             result_file.write(xmlstr)
 
         if unit_rc.returncode or doc_rc.returncode or fmt_rc.returncode:

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -62,9 +62,6 @@ class CargoTestTask(TaskExtensionPoint):
             logger.error(str(e))
             return 1
 
-        # Disable color to avoid escape sequences in test result file
-        env['NO_COLOR'] = '1'
-
         if CARGO_EXECUTABLE is None:
             # TODO(luca) log this as error in the test result file
             raise RuntimeError("Could not find 'cargo' executable")

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -67,7 +67,8 @@ class CargoTestTask(TaskExtensionPoint):
 
         if CARGO_EXECUTABLE is None:
             # TODO(luca) log this as error in the test result file
-            raise RuntimeError("Could not find 'cargo' executable")
+            logger.error("Could not find 'cargo' executable")
+            return 1
 
         cargo_args = args.cargo_args
         if cargo_args is None:

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -89,7 +89,6 @@ class CargoTestTask(TaskExtensionPoint):
             # the return code should still be 0
         return 0
 
-    # Overridden by colcon-ros-cargo
     def _test_cmd(self, cargo_args):
         args = self.context.args
         return [

--- a/colcon_cargo/task/cargo/test.py
+++ b/colcon_cargo/task/cargo/test.py
@@ -38,6 +38,8 @@ class CargoTestTask(TaskExtensionPoint):
         logger.info(
             "Testing Cargo package in '{args.path}'".format_map(locals()))
 
+        assert os.path.exists(args.build_base)
+
         test_results_path = os.path.join(args.build_base, 'cargo_test.xml')
 
         try:

--- a/test/rust-sample-package/src/lib.rs
+++ b/test/rust-sample-package/src/lib.rs
@@ -1,0 +1,5 @@
+/// Failing doctest example
+/// ```
+/// invalid_syntax
+/// ```
+pub struct Type;

--- a/test/rust-sample-package/src/main.rs
+++ b/test/rust-sample-package/src/main.rs
@@ -1,3 +1,17 @@
 fn main() {
     println!("Hello, world!");
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn ok() -> Result<(), ()> {
+        Ok(())
+    }
+
+    #[test]
+    fn err() -> Result<(), ()> {
+        Err(())
+    }
+}

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -12,6 +12,7 @@ iterdir
 linter
 lstrip
 luca
+minidom
 monkeypatch
 nargs
 noqa
@@ -35,3 +36,6 @@ thomas
 tmpdir
 todo
 toml
+toprettyxml
+tostring
+xmlstr

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,7 +4,10 @@ asyncio
 autouse
 colcon
 completers
+deps
 easymov
+etree
+getroot
 iterdir
 linter
 lstrip
@@ -25,6 +28,9 @@ setuptools
 skipif
 symlink
 tempfile
+testcase
+testsuite
+testsuites
 thomas
 tmpdir
 todo

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -24,6 +24,7 @@ returncode
 rglob
 rmtree
 rtype
+rustfmt
 scspell
 setuptools
 skipif

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -84,7 +84,7 @@ def test_build_and_test_package():
             # Executable in windows have a .exe extension
             if os.name == 'nt':
                 app_name += '.exe'
-            assert (install_base / 'bin' / app_name).is_file()
+            assert (install_base / 'debug' / app_name).is_file()
 
             # Now compile tests
             task = CargoTestTask()

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -117,9 +117,6 @@ def check_result_file(path):
     unit_result = testsuite.find("testcase[@name='unit']")
     assert unit_result is not None
     assert unit_result.find('failure') is not None
-    doc_result = testsuite.find("testcase[@name='doc']")
-    assert doc_result is not None
-    assert doc_result.find('failure') is not None
     fmt_result = testsuite.find("testcase[@name='fmt']")
     assert fmt_result is not None
     assert fmt_result.find('failure') is None

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -84,7 +84,7 @@ def test_build_and_test_package():
             # Executable in windows have a .exe extension
             if os.name == 'nt':
                 app_name += '.exe'
-            assert (install_base / 'debug' / app_name).is_file()
+            assert (install_base / 'bin' / app_name).is_file()
 
             # Now compile tests
             task = CargoTestTask()


### PR DESCRIPTION
Closes https://github.com/colcon/colcon-cargo/issues/3
This PR improves support for cargo test by adding test result generation, as well as support for doc tests and `cargo fmt` tests.

I made the following choices:

* Collate all results from each command (`cargo test` and `cargo fmt`) into a single test and report whether the whole command succeeded or failed as a single test case. This is different from the "grep approach", but that is imho not a very reliable idea because there is no guarantee that the human readable formatting will stay the same and it might break without any notice. The alternative of using json requires nightly so that is also out of the question (until it is stabilized, at which point we should revisit this implementation).
* Export all cargo test results into a single `cargo_test.xml` file, similar to what we do for Python packages (`pytest.xml`) but different from what we do for C++ packages. Happy to revisit this if there is a strong feeling.
* By default run unit tests and fmt. I haven't implemented command line arguments to set which tests to run yet, that can be done either here or in a followup PR.

What's next:

- [ ] Add parameter to enable / disable fmt, unit tests.
- [x] Integrate with `colcon-ros-cargo`. https://github.com/colcon/colcon-ros-cargo/pull/19
- [ ] Adding `time` to the test result file, I didn't add it first because `cargo test` already reports time but we are not parsing it, and reimplementing a stopwatch in Python feels unnecessary.
- [ ] Test granularity (i.e. number of tests, what failed and what didn't). Depend on a larger refactor when json or xml outputs are stable
- [ ] Figure out how to add doctests (pure binary packages fail doctest with the same exit code as a failing test)