### PR TITLE
Skip install step when a package has nothing to install

### DIFF
--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -150,7 +150,7 @@ class CargoBuildTask(TaskExtensionPoint):
         for package in metadata.get('packages', {}):
             for target in package.get('targets', {}):
                 for crate_type in target.get('crate_types', {}):
-                    if crate_type == 'bins':
+                    if crate_type == 'bin':
                         # If any one binary exists in the package then we should
                         # go ahead and run cargo install
                         return True

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -1,8 +1,8 @@
 # Copyright 2018 Easymov Robotics
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
 import json
+from pathlib import Path
 import shutil
 
 from colcon_cargo.task.cargo import CARGO_EXECUTABLE
@@ -138,21 +138,21 @@ class CargoBuildTask(TaskExtensionPoint):
         ]
 
         rc = await run(
-            self.context, cmd, cwd=self.context.pkg.path, capture_output=True, env=env
+            self.context, cmd, cwd=self.context.pkg.path, capture_output=True, env=env  # noqa: E501
         )
         if rc is None or rc.returncode != 0:
-            raise RuntimeError("Could not inspect package using 'cargo metadata'")
+            raise RuntimeError("Could not inspect package using 'cargo metadata'")  # noqa: E501
 
         if rc.stdout is None:
-            raise RuntimeError("Failed to capture stdout from 'cargo metadata'")
+            raise RuntimeError("Failed to capture stdout from 'cargo metadata'")  # noqa: E501
 
         metadata = json.loads(rc.stdout)
         for package in metadata.get('packages', {}):
             for target in package.get('targets', {}):
                 for crate_type in target.get('crate_types', {}):
                     if crate_type == 'bin':
-                        # If any one binary exists in the package then we should
-                        # go ahead and run cargo install
+                        # If any one binary exists in the package then we
+                        # should go ahead and run cargo install
                         return True
 
         # If no binary target exists in the whole package, then skip running

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -138,13 +138,21 @@ class CargoBuildTask(TaskExtensionPoint):
         ]
 
         rc = await run(
-            self.context, cmd, cwd=self.context.pkg.path, capture_output=True, env=env  # noqa: E501
+            self.context,
+            cmd,
+            cwd=self.context.pkg.path,
+            capture_output=True,
+            env=env
         )
         if rc is None or rc.returncode != 0:
-            raise RuntimeError("Could not inspect package using 'cargo metadata'")  # noqa: E501
+            raise RuntimeError(
+                "Could not inspect package using 'cargo metadata'"
+            )
 
         if rc.stdout is None:
-            raise RuntimeError("Failed to capture stdout from 'cargo metadata'")  # noqa: E501
+            raise RuntimeError(
+                "Failed to capture stdout from 'cargo metadata'"
+            )
 
         metadata = json.loads(rc.stdout)
         for package in metadata.get('packages', {}):

--- a/test/rust-pure-library/Cargo.toml
+++ b/test/rust-pure-library/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-pure-library"
+version = "0.1.0"
+authors = ["Luca Della Vedova<lucadv@intrinsic.ai>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test/rust-pure-library/src/lib.rs
+++ b/test/rust-pure-library/src/lib.rs
@@ -1,0 +1,1 @@
+pub struct Type;


### PR DESCRIPTION
As mentioned in https://github.com/colcon/colcon-cargo/pull/39#issuecomment-2306010474. Originally authored in https://github.com/luca-della-vedova/colcon-cargo/pull/2 by @mxgrey, I only contributed unit tests to make sure the functionality works as intended and no regressions are added unintentionally.

Original PR description:

While testing out `colcon test` for `colcon-cargo`, I found that we get a build error from `colcon build` if there's a Rust package that does not contain any binary crates (i.e. it only contains a library crate).

This PR avoids that problem by checking each cargo package before running `cargo install` to ensure it contains at least one binary crate. If there are no binary crates in the package then we simply skip the `cargo install` step to avoid the spurious error code.

With this, we can successfully use `colcon build` followed by `colcon test` to run tests for library-only cargo packages.