### PR TITLE
Bump minor version for release

### DIFF
--- a/colcon_cargo/__init__.py
+++ b/colcon_cargo/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Easymov Robotics
 # Licensed under the Apache License, Version 2.0
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'


### PR DESCRIPTION
Closes https://github.com/colcon/colcon-cargo/issues/22
`colcon-cargo` has been [released on Pypi](https://pypi.org/project/colcon-cargo/)! I bumped the minor version to keep it a bit more unique and released this. Once it's merged I'll tag the commit.
It's not released yet on packagecloud since I'm not part of the colcon org, I'll try to get added but if anyone else has the rights and wants to push this branch feel free!