### PR TITLE
Improve TOML library compatibility

### DIFF
--- a/colcon_cargo/package_identification/cargo.py
+++ b/colcon_cargo/package_identification/cargo.py
@@ -5,7 +5,18 @@ from colcon_core.logging import colcon_logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
 from colcon_core.plugin_system import satisfies_version
-import toml
+
+try:
+    # Python 3.11+
+    from tomllib import loads as toml_loads
+    from tomllib import TOMLDecodeError
+except ImportError:
+    try:
+        from tomli import loads as toml_loads
+        from tomli import TOMLDecodeError
+    except ImportError:
+        from toml import loads as toml_loads
+        from toml import TomlDecodeError as TOMLDecodeError
 
 logger = colcon_logger.getChild(__name__)
 WORKSPACE = 'WORKSPACE'
@@ -52,8 +63,9 @@ def extract_data(cargo_toml):
     """
     content = {}
     try:
-        content = toml.load(str(cargo_toml))
-    except toml.TomlDecodeError:
+        with cargo_toml.open('rb') as f:
+            content = toml_loads(f.read().decode())
+    except TOMLDecodeError:
         logger.error('Decoding error when processing "%s"'
                      % cargo_toml.absolute())
         return

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ keywords = colcon
 python_requires = >=3.6
 install_requires =
   colcon-core
-  toml
+  # toml is also supported but deprecated
+  tomli>=1.0.0; python_version < "3.11"
 packages = find:
 zip_safe = true
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-cargo]
 No-Python2:
-Depends3: python3-colcon-core, python3-toml
+Depends3: python3-colcon-core, python3 (>= 3.11) | python3-tomli (>= 1) | python3-toml
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6
 Debian-Version: 100

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -37,6 +37,8 @@ thomas
 tmpdir
 todo
 toml
+tomli
+tomllib
 toprettyxml
 tostring
 xmlstr


### PR DESCRIPTION
Python 3.11 adds a TOML parser to the standard library. For older versions of Python, the 'tomli' package is nearly perfectly compatible.

For platforms which don't package tomli or a new enough version of Python (i.e. Ubuntu Focal), we can fall back to 'toml'.

This is the same approach taken by `colcon-core` itself to parse `pyproject.toml` files:
https://github.com/colcon/colcon-core/blob/a74fa97fcea08d1e276a327228c119ce78aa0075/colcon_core/python_project/spec.py#L4-L11