### PR TITLE
Add package version to metadata

### DIFF
--- a/colcon_cargo/package_identification/cargo.py
+++ b/colcon_cargo/package_identification/cargo.py
@@ -50,6 +50,8 @@ class CargoPackageIdentification(PackageIdentificationExtensionPoint):
         metadata.type = 'cargo'
         if metadata.name is None:
             metadata.name = data['name']
+        metadata.metadata['version'] = data['version']
+
         metadata.dependencies['build'] |= data['depends']
         metadata.dependencies['run'] |= data['depends']
 
@@ -78,6 +80,7 @@ def extract_data(cargo_toml):
     toml_name_attr = extract_project_name(content)
     data['name'] = toml_name_attr if toml_name_attr is not None else \
         cargo_toml.parent.name
+    data['version'] = extract_project_version(content)
 
     depends = extract_dependencies(content)
     # exclude self references
@@ -96,6 +99,20 @@ def extract_project_name(content):
     """
     try:
         return content['package']['name']
+    except KeyError:
+        return None
+
+
+def extract_project_version(content):
+    """
+    Extract the Cargo project version from the Cargo.toml file.
+
+    :param str content: The Cargo.toml parsed dictionary
+    :returns: The project version, otherwise None
+    :rtype: str
+    """
+    try:
+        return content['package']['version']
     except KeyError:
         return None
 


### PR DESCRIPTION
The package version is typically read during the augmentation phase, but this package doesn't have one (yet). Since the dependencies are already being read during identification, go ahead and read the version then as well.

Here's where this is populated for Python packages: https://github.com/colcon/colcon-core/blob/a74fa97fcea08d1e276a327228c119ce78aa0075/colcon_core/package_augmentation/python.py#L48-L50