### PR TITLE
Use a consistent profile between 'build' and 'install'

### DIFF
--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -108,17 +108,23 @@ class CargoBuildTask(TaskExtensionPoint):
     # Overridden by colcon-ros-cargo
     def _build_cmd(self, cargo_args):
         args = self.context.args
-        return [
+        cmd = [
             CARGO_EXECUTABLE,
             'build',
             '--quiet',
             '--target-dir', args.build_base,
-        ] + cargo_args
+        ]
+        if not any(
+            arg == '--profile' or arg.startswith('--profile=')
+            for arg in cargo_args
+        ):
+            cmd += ['--profile', 'dev']
+        return cmd + cargo_args
 
     # Overridden by colcon-ros-cargo
     def _install_cmd(self, cargo_args):
         args = self.context.args
-        return [
+        cmd = [
             CARGO_EXECUTABLE,
             'install',
             '--force',
@@ -127,7 +133,13 @@ class CargoBuildTask(TaskExtensionPoint):
             '--path', '.',
             '--root', args.install_base,
             '--target-dir', args.build_base,
-        ] + cargo_args
+        ]
+        if not any(
+            arg == '--profile' or arg.startswith('--profile=')
+            for arg in cargo_args
+        ):
+            cmd += ['--profile', 'dev']
+        return cmd + cargo_args
 
     # Identify if there are any binaries to install for the current package
     async def _has_binaries(self, env):


### PR DESCRIPTION
Choose 'dev' as the default profile (to align with 'build'). Of course the developer can override this with `--cargo-args --profile release` similar to how CMake developers use `--cmake-args -DCMAKE_BUILD_TYPE=Release`.

Right now, 'build' and 'install' use 'dev' and 'release' respectively, meaning that you always compile everything twice.