### PR TITLE
Implement separate augmentation phase for Cargo packages

### DIFF
--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -1,0 +1,89 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from colcon_cargo.package_identification.cargo import read_cargo_toml
+from colcon_core.dependency_descriptor import DependencyDescriptor
+from colcon_core.package_augmentation \
+    import PackageAugmentationExtensionPoint
+from colcon_core.plugin_system import satisfies_version
+
+
+class CargoPackageAugmentation(PackageAugmentationExtensionPoint):
+    """Augment cargo packages with information from Cargo.toml files."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            PackageAugmentationExtensionPoint.EXTENSION_POINT_VERSION,
+            '^1.0')
+
+    def augment_package(  # noqa: D102
+        self, metadata, *, additional_argument_names=None
+    ):
+        if metadata.type != 'cargo':
+            return
+
+        self._augment_package(
+            metadata, additional_argument_names=additional_argument_names)
+
+    def _augment_package(
+        self, metadata, *, additional_argument_names=None
+    ):
+        cargo_toml = metadata.path / 'Cargo.toml'
+        if not cargo_toml.is_file():
+            return
+
+        content = read_cargo_toml(cargo_toml)
+        package = content.get('package', {})
+        if not package:
+            return
+
+        version = package.get('version', '0.0.0')
+        if not metadata.metadata.get('version'):
+            metadata.metadata['version'] = version
+
+        dependencies = extract_dependencies(content)
+        for k, v in dependencies.items():
+            metadata.dependencies[k] |= v
+
+        authors = package.get('authors', ())
+        if authors:
+            metadata.metadata.setdefault('maintainers', [])
+            metadata.metadata['maintainers'] += authors
+
+
+def extract_dependencies(content):
+    """
+    Get the dependencies of a Cargo package.
+
+    :param content: The dictionary content of the Cargo.tml file
+    :returns: The dependencies
+    :rtype: dict(string, set(DependencyDescriptor))
+    """
+    name = content.get('name')
+    depends = {
+        create_dependency_descriptor(k, v)
+        for k, v in content.get('dependencies', {}).items()
+        if k != name
+    }
+    return {
+        'build': depends,
+        'run': depends,
+    }
+
+
+def create_dependency_descriptor(name, constraints):
+    """
+    Create a dependency descriptor from a Cargo dependency specification.
+
+    :param name: The name of the dependee
+    :param constraints: The dependency constraints, either a string or
+      a dict
+    :rtype: DependencyDescriptor
+    """
+    metadata = {
+        'origin': 'cargo',
+    }
+    # TODO: Interpret SemVer constraints and add appropriate constraint
+    #       metadata. Handling arbitrary wildcards will be non-trivial.
+    return DependencyDescriptor(name, metadata=metadata)

--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -56,7 +56,7 @@ def extract_dependencies(content):
     """
     Get the dependencies of a Cargo package.
 
-    :param content: The dictionary content of the Cargo.tml file
+    :param content: The dictionary content of the Cargo.toml file
     :returns: The dependencies
     :rtype: dict(string, set(DependencyDescriptor))
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,8 @@ markers =
 [options.entry_points]
 colcon_argcomplete.argcomplete_completer =
     cargo_args = colcon_cargo.argcomplete_completer.cargo_args:CargoArgcompleteCompleter
+colcon_core.package_augmentation =
+    cargo = colcon_cargo.package_augmentation.cargo:CargoPackageAugmentation
 colcon_core.package_identification =
     cargo = colcon_cargo.package_identification.cargo:CargoPackageIdentification
 colcon_core.task.build =

--- a/test/rust-pure-library/Cargo.toml
+++ b/test/rust-pure-library/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "rust-pure-library"
 version = "0.1.0"
-authors = ["Luca Della Vedova<lucadv@intrinsic.ai>"]
+authors = ["Test<test@test.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+either = "1.13.0"

--- a/test/rust-sample-package/Cargo.toml
+++ b/test/rust-sample-package/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+either = "1.13.0"

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,6 +4,7 @@ asyncio
 autouse
 colcon
 completers
+dependee
 deps
 easymov
 etree
@@ -41,4 +42,5 @@ tomli
 tomllib
 toprettyxml
 tostring
+wildcards
 xmlstr

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -9,6 +9,7 @@ import tempfile
 from types import SimpleNamespace
 import xml.etree.ElementTree as eTree
 
+from colcon_cargo.package_augmentation.cargo import CargoPackageAugmentation
 from colcon_cargo.package_identification.cargo import CargoPackageIdentification  # noqa: E501
 from colcon_cargo.task.cargo.build import CargoBuildTask
 from colcon_cargo.task.cargo.test import CargoTestTask
@@ -41,6 +42,21 @@ def test_package_identification():
     cpi.identify(desc)
     assert desc.type == 'cargo'
     assert desc.name == TEST_PACKAGE_NAME
+
+
+def test_package_augmentation():
+    cpi = CargoPackageIdentification()
+    aug = CargoPackageAugmentation()
+    desc = PackageDescriptor(pure_library_path)
+    cpi.identify(desc)
+    aug.augment_package(desc)
+    print(desc)
+    assert desc.metadata['version'] == '0.1.0'
+    assert len(desc.metadata['maintainers']) == 1
+    assert desc.metadata['maintainers'][0] == 'Test<test@test.com>'
+    assert len(desc.dependencies['build']) == 1
+    assert 'either' in desc.dependencies['build']
+    assert desc.dependencies['run'] == desc.dependencies['build']
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
In addition to moving non-identity package metadata out of the `CargoPackageIdentification` extension and into a new `CargoPackageAugmentation` extension, this change also:
1. Converts dependencies to use the DependencyDescriptor type
2. Adds "author" metadata to colcon's "maintainer" metadata
3. Interprets unspecified versions as 0.0.0 ([per cargo docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field))