### PR TITLE
Include package source information on cargo dependencies

### DIFF
--- a/test/rust-sample-package/Cargo.toml
+++ b/test/rust-sample-package/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-either = "1.13.0"
+rust-pure-library = {path = "../rust-pure-library"}

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -11,6 +11,7 @@ etree
 getroot
 iterdir
 linter
+localhost
 lstrip
 luca
 minidom


### PR DESCRIPTION
This information is necessary to perform arbitrary dependency patching later in the cargo build process.

A value of `None` is intended to represent whatever the default registry is set to, which itself would default to `crates-io`. I tested that `path` and `git` were available to be patched as well, though local paths needed to be resolved as a `file://` URI. to do so.