### PR TITLE
Don't install crate tracking files

### DIFF
--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -133,6 +133,7 @@ class CargoBuildTask(TaskExtensionPoint):
             '--path', '.',
             '--root', args.install_base,
             '--target-dir', args.build_base,
+            '--no-track',
         ]
         if not any(
             arg == '--profile' or arg.startswith('--profile=')


### PR DESCRIPTION
I'm not aware of any build processes in colcon which modify or append to files in the install tree. Since we aren't using these files anyway, we should avoid installing them.

https://doc.rust-lang.org/cargo/commands/cargo-install.html#install-options
> By default, Cargo keeps track of the installed packages with a metadata file stored in the installation root directory. This flag tells Cargo not to use or create that file. With this flag, Cargo will refuse to overwrite any existing files unless the --force flag is used. This also disables Cargo’s ability to protect against multiple concurrent invocations of Cargo installing at the same time.

We're already getting `--force` on this command, and I can't see any reason why installation operations need be aware of each other.