### PR TITLE
Collect crate metadata during 'prepare' phase of build

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -29,6 +29,7 @@ rustfmt
 scspell
 setuptools
 skipif
+staticmethod
 symlink
 tempfile
 testcase


### PR DESCRIPTION
* If metadata collection fails for some reason, it would be good if we hadn't already performed any operations on the package.
* It would be good to have the metadata earlier in the process so we can use it in other operations.