### PR TITLE
Add support for cargo dependency renaming

### DIFF
--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -79,7 +79,7 @@ def create_dependency_descriptor(name, constraints, path):
     """
     Create a dependency descriptor from a Cargo dependency specification.
 
-    :param name: The name of the dependee
+    :param name: The name of the dependee as it is imported
     :param constraints: The dependency constraints, either a string or
       a dict
     :param path: The directory from where relative paths should be
@@ -94,6 +94,7 @@ def create_dependency_descriptor(name, constraints, path):
         else:
             source = constraints.get('git') or \
                 constraints.get('registry')
+        name = constraints.get('package', name)
     else:
         source = None
     metadata = {

--- a/test/rust-sample-package/Cargo.toml
+++ b/test/rust-sample-package/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-pure-library = {path = "../rust-pure-library"}
+local-rust-pure-library = {package = "rust-pure-library", path = "../rust-pure-library"}


### PR DESCRIPTION
It is possible to reference a crate using an import name other than its package name. The package name and import name are typically the same, but when they differ, we should use the package name to construct the dependency graph. The import name is of no consequence outside of the package being built.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml