### PR TITLE
Use target 'kind' to detect 'bin' crates

### DIFF
--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -180,8 +180,8 @@ class CargoBuildTask(TaskExtensionPoint):
     def _has_binaries(metadata):
         for package in metadata.get('packages', {}):
             for target in package.get('targets', {}):
-                for crate_type in target.get('crate_types', {}):
-                    if crate_type == 'bin':
+                for kind in target.get('kind', {}):
+                    if kind == 'bin':
                         # If any one binary exists in the package then we
                         # should go ahead and run cargo install
                         return True


### PR DESCRIPTION
The crate type can be 'bin' when building benchmark targets, so we should use the 'kind' instead to detect when we'll want to perform a cargo install.

Here's  the relevant excerpt from `cargo metadata` on `rust-pure-library`:
```json
      "targets": [
        {
          "kind": [
            "lib"
          ],
          "crate_types": [
            "lib"
          ],
          "name": "rust_pure_library",
          "src_path": "/home/cottsay/colcon_ws/src/colcon-cargo/test/rust-pure-library/src/lib.rs",
          "edition": "2018",
          "doc": true,
          "doctest": true,
          "test": true
        },
        {
          "kind": [
            "bench"
          ],
          "crate_types": [
            "bin"
          ],
          "name": "bench",
          "src_path": "/home/cottsay/colcon_ws/src/colcon-cargo/test/rust-pure-library/benches/bench.rs",
          "edition": "2018",
          "doc": false,
          "doctest": false,
          "test": false
        }
      ],
```

Using the 'kind' is the same approach as was [taken in the Fedora cargo2rpm project](https://pagure.io/fedora-rust/cargo2rpm/blob/56328e9253bc15b4443b76f5a2298ff3e637a6d0/f/cargo2rpm/metadata.py#_320) when performing pretty much the same detection for the same purpose.