### PR TITLE
Extract target-specific dependencies

### DIFF
--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -48,6 +48,11 @@ class CargoPackageAugmentation(PackageAugmentationExtensionPoint):
         for k, v in dependencies.items():
             metadata.dependencies[k] |= v
 
+        for category, spec in content.get('target', {}).items():
+            dependencies = extract_dependencies(spec, metadata.path)
+            for k, v in dependencies.items():
+                metadata.dependencies[k] |= v
+
         authors = package.get('authors', ())
         if authors:
             metadata.metadata.setdefault('maintainers', [])

--- a/test/rust-sample-package/Cargo.toml
+++ b/test/rust-sample-package/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [dependencies]
 local-rust-pure-library = {package = "rust-pure-library", path = "../rust-pure-library"}
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = "0.59"

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -47,6 +47,7 @@ def test_package_identification():
 def test_package_augmentation():
     cpi = CargoPackageIdentification()
     aug = CargoPackageAugmentation()
+
     desc = PackageDescriptor(pure_library_path)
     cpi.identify(desc)
     aug.augment_package(desc)
@@ -56,6 +57,15 @@ def test_package_augmentation():
     assert desc.metadata['maintainers'][0] == 'Test<test@test.com>'
     assert len(desc.dependencies['build']) == 1
     assert 'either' in desc.dependencies['build']
+    assert desc.dependencies['run'] == desc.dependencies['build']
+
+    desc = PackageDescriptor(test_project_path)
+    cpi.identify(desc)
+    aug.augment_package(desc)
+    print(desc)
+    assert len(desc.dependencies['build']) == 2
+    assert PURE_LIBRARY_PACKAGE_NAME in desc.dependencies['build']
+    assert 'windows-sys' in desc.dependencies['build']
     assert desc.dependencies['run'] == desc.dependencies['build']
 
 
@@ -87,9 +97,11 @@ def test_path_dependencies():
     desc = PackageDescriptor(test_project_path)
     cpi.identify(desc)
     aug.augment_package(desc)
-    assert PURE_LIBRARY_PACKAGE_NAME in desc.dependencies['build']
-    assert len(desc.dependencies['build']) == 1
-    dep = desc.dependencies['build'].pop()
+    for dep in desc.dependencies['build']:
+        if dep.name == PURE_LIBRARY_PACKAGE_NAME:
+            break
+    else:
+        assert False, f'{PURE_LIBRARY_PACKAGE_NAME} not in build deps'
     assert 'cargo_source' in dep.metadata
     assert dep.metadata['cargo_source'] is not None
     # Path.from_uri was only added in Python 3.13


### PR DESCRIPTION
It appears that cargo will look for target-specific dependencies even when the dependencies do not apply to the current platform. This saves us the trouble of parsing the `cfg()` logic.