### PR TITLE
Extract {build,dev}-dependencies

### DIFF
--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -69,9 +69,19 @@ def extract_dependencies(content, path):
         for k, v in content.get('dependencies', {}).items()
         if k != name
     }
+    build_depends = {
+        create_dependency_descriptor(k, v, path)
+        for k, v in content.get('build-dependencies', {}).items()
+        if k != name
+    }
+    dev_depends = {
+        create_dependency_descriptor(k, v, path)
+        for k, v in content.get('dev-dependencies', {}).items()
+        if k != name
+    }
     return {
-        'build': depends,
-        'run': depends,
+        'build': depends | build_depends | dev_depends,
+        'run': depends | build_depends,
     }
 
 

--- a/test/rust-sample-package/Cargo.toml
+++ b/test/rust-sample-package/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [dependencies]
 local-rust-pure-library = {package = "rust-pure-library", path = "../rust-pure-library"}
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -32,6 +32,7 @@ setuptools
 skipif
 staticmethod
 symlink
+tempdir
 tempfile
 testcase
 testsuite

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -47,6 +47,7 @@ def test_package_identification():
 def test_package_augmentation():
     cpi = CargoPackageIdentification()
     aug = CargoPackageAugmentation()
+
     desc = PackageDescriptor(pure_library_path)
     cpi.identify(desc)
     aug.augment_package(desc)
@@ -57,6 +58,16 @@ def test_package_augmentation():
     assert len(desc.dependencies['build']) == 1
     assert 'either' in desc.dependencies['build']
     assert desc.dependencies['run'] == desc.dependencies['build']
+
+    desc = PackageDescriptor(test_project_path)
+    cpi.identify(desc)
+    aug.augment_package(desc)
+    print(desc)
+    assert len(desc.dependencies['build']) == 2
+    assert PURE_LIBRARY_PACKAGE_NAME in desc.dependencies['build']
+    assert 'tempdir' in desc.dependencies['build']
+    assert len(desc.dependencies['run']) == 1
+    assert PURE_LIBRARY_PACKAGE_NAME in desc.dependencies['run']
 
 
 # Ported from Python 3.13 implementation
@@ -87,9 +98,11 @@ def test_path_dependencies():
     desc = PackageDescriptor(test_project_path)
     cpi.identify(desc)
     aug.augment_package(desc)
-    assert PURE_LIBRARY_PACKAGE_NAME in desc.dependencies['build']
-    assert len(desc.dependencies['build']) == 1
-    dep = desc.dependencies['build'].pop()
+    for dep in desc.dependencies['build']:
+        if dep.name == PURE_LIBRARY_PACKAGE_NAME:
+            break
+    else:
+        assert False, f'{PURE_LIBRARY_PACKAGE_NAME} not in build deps'
     assert 'cargo_source' in dep.metadata
     assert dep.metadata['cargo_source'] is not None
     # Path.from_uri was only added in Python 3.13


### PR DESCRIPTION
The build-dependencies are needed by build scripts, which makes it a sort of "export" or "devel" dependency of the package. Since colcon doesn't currently disambiguate between this class and "run" dependencies, we will need to include the dependencies under "run".

The "dev" dependencies however are not needed for dependees of a package, and only the package itself.

This will clearly conflict with #57 - I'll take care of the resolution once one of these two gets merged.