### PR TITLE
Filter out false detection of circular dependencies

### DIFF
--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -73,7 +73,6 @@ def extract_dependencies(package_name, content, path):
     :returns: The dependencies
     :rtype: dict(string, set(DependencyDescriptor))
     """
-
     depends = {
         create_dependency_descriptor(k, v, path)
         for k, v in filter_dependency_list(

--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -45,12 +45,16 @@ class CargoPackageAugmentation(PackageAugmentationExtensionPoint):
         if not metadata.metadata.get('version'):
             metadata.metadata['version'] = version
 
-        dependencies = extract_dependencies(package_name, content, metadata.path)
+        dependencies = extract_dependencies(
+            package_name, content, metadata.path
+        )
         for k, v in dependencies.items():
             metadata.dependencies[k] |= v
 
         for category, spec in content.get('target', {}).items():
-            dependencies = extract_dependencies(package_name, spec, metadata.path)
+            dependencies = extract_dependencies(
+                package_name, spec, metadata.path
+            )
             for k, v in dependencies.items():
                 metadata.dependencies[k] |= v
 

--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -100,6 +100,15 @@ def extract_dependencies(package_name, content, path):
 
 
 def filter_dependency_list(dependencies, filter_out=None):
+    """
+    Find the external names of dependencies and optionally filter out any that
+    match a pattern.
+
+    :param dependencies: The dictionary of every dependency and its constraints
+    :param filter_out: The name of a dependency to filter out.
+    :returns: The filtered dependency list with the external names as keys
+    :rtype: dict(string, dict)
+    """
     filtered_dependencies = {}
     for dependency, constraints in dependencies:
         if isinstance(constraints, dict):

--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -90,7 +90,7 @@ def extract_dependencies(package_name, content, path):
         create_dependency_descriptor(k, v, path)
         for k, v in filter_dependency_list(
             content.get('dev-dependencies', {}).items(),
-            package_name,
+            filter_out=package_name,
         )
     }
     return {
@@ -99,7 +99,7 @@ def extract_dependencies(package_name, content, path):
     }
 
 
-def filter_dependency_list(dependencies, filter_out = None):
+def filter_dependency_list(dependencies, filter_out=None):
     filtered_dependencies = {}
     for dependency, constraints in dependencies:
         if isinstance(constraints, dict):

--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -73,22 +73,25 @@ def extract_dependencies(package_name, content, path):
     :returns: The dependencies
     :rtype: dict(string, set(DependencyDescriptor))
     """
-    target_name = content.get('name')
 
     depends = {
-        create_dependency_descriptor(target_name, k, v, path)
-        for k, v in content.get('dependencies', {}).items()
-        if k != target_name and k != package_name
+        create_dependency_descriptor(k, v, path)
+        for k, v in filter_dependency_list(
+            content.get('dependencies', {}).items()
+        )
     }
     build_depends = {
-        create_dependency_descriptor(target_name, k, v, path)
-        for k, v in content.get('build-dependencies', {}).items()
-        if k != target_name and k != package_name
+        create_dependency_descriptor(k, v, path)
+        for k, v in filter_dependency_list(
+            content.get('build-dependencies', {}).items()
+        )
     }
     dev_depends = {
-        create_dependency_descriptor(target_name, k, v, path)
-        for k, v in content.get('dev-dependencies', {}).items()
-        if k != target_name and k != package_name
+        create_dependency_descriptor(k, v, path)
+        for k, v in filter_dependency_list(
+            content.get('dev-dependencies', {}).items(),
+            package_name,
+        )
     }
     return {
         'build': depends | build_depends | dev_depends,
@@ -96,7 +99,19 @@ def extract_dependencies(package_name, content, path):
     }
 
 
-def create_dependency_descriptor(package, name, constraints, path):
+def filter_dependency_list(dependencies, filter_out = None):
+    filtered_dependencies = {}
+    for dependency, constraints in dependencies:
+        if isinstance(constraints, dict):
+            dependency = constraints.get('package', dependency)
+
+        if dependency != filter_out:
+            filtered_dependencies[dependency] = constraints
+
+    return filtered_dependencies.items()
+
+
+def create_dependency_descriptor(dependency_name, constraints, path):
     """
     Create a dependency descriptor from a Cargo dependency specification.
 
@@ -115,7 +130,6 @@ def create_dependency_descriptor(package, name, constraints, path):
         else:
             source = constraints.get('git') or \
                 constraints.get('registry')
-        name = constraints.get('package', name)
     else:
         source = None
     metadata = {
@@ -124,4 +138,4 @@ def create_dependency_descriptor(package, name, constraints, path):
     }
     # TODO: Interpret SemVer constraints and add appropriate constraint
     #       metadata. Handling arbitrary wildcards will be non-trivial.
-    return DependencyDescriptor(name, metadata=metadata)
+    return DependencyDescriptor(dependency_name, metadata=metadata)

--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -100,8 +100,11 @@ def extract_dependencies(package_name, content, path):
 
 def filter_dependency_list(dependencies, filter_out=None):
     """
+    Filter dependency names.
+
     Find the external names of dependencies and optionally filter out any that
-    match a pattern.
+    match a pattern. The filtering is used for dev-dependencies which may have
+    the package itself as a dependency.
 
     :param dependencies: The dictionary of every dependency and its constraints
     :param filter_out: The name of a dependency to filter out.

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -10,7 +10,6 @@ spell_check_words_path = Path(__file__).parent / 'spell_check.words'
 
 @pytest.fixture(scope='module')
 def known_words():
-    global spell_check_words_path
     return spell_check_words_path.read_text().splitlines()
 
 


### PR DESCRIPTION
While testing this PR out against a colcon workspace containing [bevy](https://github.com/bevyengine/bevy) I ran into a bug that failed to filter out a false detection of a circular dependency.

When identifying dependencies per target, there was already logic where

```python
name = content.get('name')
```

would be compared against the list of dependencies and skip the dependency if it matches `name` because it's normal for a target to depend on its own crate. However `content` isn't guaranteed to contain the name of a package. While testing bevy, `content.get('name')` was always returning `None`.

Instead, the `package` information does reliably contain a `name` field, so I fixed this issue by obtaining the name from `package` ahead of time and passing that into every call of `extract_dependencies`. This allows the targets to correctly know which package they are inside of.