### PR TITLE
fix: discover non Cargo packages in a Cargo workspace

### DIFF
--- a/colcon_cargo/package_discovery/cargo_workspace.py
+++ b/colcon_cargo/package_discovery/cargo_workspace.py
@@ -35,6 +35,7 @@ class CargoWorkspacePackageDiscovery(PackageDiscoveryExtensionPoint):
             for extension in extensions_same_prio.values():
                 if isinstance(extension, CargoWorkspaceIdentification):
                     paths.update(extension.workspace_package_paths)
+                    paths.update(extension.non_cargo_paths)
                     extension.workspace_package_paths.clear()
 
         descs = set()

--- a/colcon_cargo/package_identification/cargo_workspace.py
+++ b/colcon_cargo/package_identification/cargo_workspace.py
@@ -55,7 +55,9 @@ class CargoWorkspaceIdentification(PackageIdentificationExtensionPoint):
         self.workspace_package_paths.update(ws_members)
 
         all_package_paths = {
-            p.parent for p in pathlib.Path(metadata.path).rglob('package.xml')
+            p.parent
+            for p in pathlib.Path(metadata.path).rglob('package.xml')
+            if not pathlib.Path(p.parent / 'Cargo.toml').is_file()
         }
 
         self.non_cargo_paths.update(


### PR DESCRIPTION
This PR adds discovery of non-Cargo packages in a Cargo workspace.

Fixes #63 