### PR TITLE
Allow specification of additional packages in workspaces

### DIFF
--- a/colcon_cargo/package_identification/cargo_workspace.py
+++ b/colcon_cargo/package_identification/cargo_workspace.py
@@ -50,6 +50,14 @@ class CargoWorkspaceIdentification(PackageIdentificationExtensionPoint):
         )
         self.workspace_package_paths.update(ws_members)
 
+        workspace_metadata = content['workspace'].get('metadata', {})
+        colcon_metadata = workspace_metadata.get('colcon', {})
+        self.workspace_package_paths.update(
+            member
+            for pattern in colcon_metadata.get('additional-packages', ())
+            for member in metadata.path.glob(pattern)
+        )
+
         if 'package' not in content:
             # Prevent any further attempts to discover packages in this
             # directory and let the workspace dictate where to look for

--- a/test/rust-workspace/Cargo.toml
+++ b/test/rust-workspace/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2018"
 [workspace]
 members = ["workspace-mem*"]
 default-members = ["workspace-mem*"]
+
+[workspace.metadata.colcon]
+additional-packages = ["additional-pack*"]

--- a/test/rust-workspace/additional-package/Cargo.toml
+++ b/test/rust-workspace/additional-package/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "additional-package"
+version = "0.1.0"
+authors = ["Test<test@test.com>"]
+edition = "2018"

--- a/test/rust-workspace/additional-package/src/main.rs
+++ b/test/rust-workspace/additional-package/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -98,10 +98,14 @@ def test_package_discovery():
             cpi.PRIORITY: {'cargo': cpi},
         })
 
-    assert len(descs) == 1
+    assert len(descs) == 2
+    descs = sorted(descs, key=lambda d: d.name)
     desc = descs.pop()
     assert desc.type == 'cargo'
     assert desc.name == 'workspace-member'
+    desc = descs.pop()
+    assert desc.type == 'cargo'
+    assert desc.name == 'additional-package'
 
 
 # Ported from Python 3.13 implementation


### PR DESCRIPTION
When cargo itself encounters a workspace, it inspects member directories for crates and does not search any other subdirectories of the workspace. The workspace support in colcon behaves the same.

It may be desirable to include additional packages in colcon's discovery which are not members of the workspace. This change adds a metadata value at `workspace.metadata.colcon.additional-packages` which behaves similarly to `workspace.members` so that packages under those paths are discovered by colcon. The packages need not be cargo packages themselves but if they are, they will not be treated as cargo workspace members but rather as independent packages.

Closes #63