### PR TITLE
Install a curated registry of crates with libraries

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ apache
 argcomplete
 asyncio
 autouse
+checksum
 colcon
 completers
 cwpd
@@ -26,6 +27,7 @@ pydocstyle
 pytest
 returncode
 rglob
+rlib
 rmtree
 rtype
 rustfmt

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -27,6 +27,7 @@ import pytest
 TEST_PACKAGE_NAME = 'rust-sample-package'
 PURE_LIBRARY_PACKAGE_NAME = 'rust-pure-library'
 WORKSPACE_PACKAGE_NAME = 'rust-workspace'
+WORKSPACE_PACKAGE_VERSION = '0.1.0'
 
 test_project_path = Path(__file__).parent / TEST_PACKAGE_NAME
 pure_library_path = Path(__file__).parent / PURE_LIBRARY_PACKAGE_NAME
@@ -170,6 +171,7 @@ def test_build_and_test_package():
                                       path=str(test_project_path),
                                       build_base=str(tmpdir / 'build'),
                                       install_base=str(tmpdir / 'install'),
+                                      symlink_install=False,
                                       clean_build=None,
                                       cargo_args=None,
                                   ),
@@ -236,6 +238,7 @@ def test_skip_pure_library_package():
                                       path=str(pure_library_path),
                                       build_base=str(tmpdir / 'build'),
                                       install_base=str(tmpdir / 'install'),
+                                      symlink_install=False,
                                       clean_build=None,
                                       cargo_args=None,
                                   ),
@@ -290,6 +293,7 @@ def test_workspace_with_package():
                                       path=str(workspace_project_path),
                                       build_base=str(tmpdir / 'build'),
                                       install_base=str(tmpdir / 'install'),
+                                      symlink_install=False,
                                       clean_build=None,
                                       cargo_args=None,
                                   ),
@@ -314,6 +318,16 @@ def test_workspace_with_package():
             # This check is specifically to ensure that other workspace
             # members didn't get installed as well
             assert len(tuple((install_base / 'bin').iterdir())) == 1
+
+            # There should also be an unpacked library create
+            registry_path = install_base / 'share' / 'cargo' / 'registry'
+            crate_path = registry_path / '-'.join((
+                WORKSPACE_PACKAGE_NAME,
+                WORKSPACE_PACKAGE_VERSION,
+            ))
+            assert tuple(registry_path.iterdir()) == (crate_path,)
+            assert (crate_path / 'Cargo.toml').is_file()
+            assert (crate_path / 'src' / 'lib.rs').is_file()
 
     finally:
         event_loop.close()


### PR DESCRIPTION
This largely mirrors the approach taken by major Linux distributions like Ubuntu and Fedora. We can curate the crates in a way that should allow us to use them in downstream package builds within this colcon workspace or downstream workspaces.

This change doesn't yet add the code necessary to instruct cargo to use our curated registry.

---

Example of an Ubuntu package:
<details>

```console
$ apt-file list librust-serde-dev
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/.cargo-checksum.json
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/.cargo_vcs_info.json
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/Cargo.toml
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/LICENSE-APACHE
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/LICENSE-MIT
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/README.md
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/build.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/crates-io.md
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/format.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/ignored_any.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/impls.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/mod.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/seed.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/size_hint.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/de/value.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/integer128.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/lib.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/macros.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/private/de.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/private/doc.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/private/mod.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/private/ser.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/ser/fmt.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/ser/impls.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/ser/impossible.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/ser/mod.rs
librust-serde-dev: /usr/share/cargo/registry/serde-1.0.195/src/std_error.rs
librust-serde-dev: /usr/share/doc/librust-serde-dev/changelog.Debian.gz
librust-serde-dev: /usr/share/doc/librust-serde-dev/copyright
```

</details>

Example of a Fedora package:

<details>

```console
$ dnf repoquery --list rust-serde-devel
Updating and loading repositories:
Repositories loaded.
/usr/share/cargo/registry/serde-1.0.210
/usr/share/cargo/registry/serde-1.0.210/.cargo-checksum.json
/usr/share/cargo/registry/serde-1.0.210/Cargo.toml
/usr/share/cargo/registry/serde-1.0.210/LICENSE-APACHE
/usr/share/cargo/registry/serde-1.0.210/LICENSE-MIT
/usr/share/cargo/registry/serde-1.0.210/README.md
/usr/share/cargo/registry/serde-1.0.210/build.rs
/usr/share/cargo/registry/serde-1.0.210/crates-io.md
/usr/share/cargo/registry/serde-1.0.210/src
/usr/share/cargo/registry/serde-1.0.210/src/de
/usr/share/cargo/registry/serde-1.0.210/src/de/ignored_any.rs
/usr/share/cargo/registry/serde-1.0.210/src/de/impls.rs
/usr/share/cargo/registry/serde-1.0.210/src/de/mod.rs
/usr/share/cargo/registry/serde-1.0.210/src/de/seed.rs
/usr/share/cargo/registry/serde-1.0.210/src/de/size_hint.rs
/usr/share/cargo/registry/serde-1.0.210/src/de/value.rs
/usr/share/cargo/registry/serde-1.0.210/src/format.rs
/usr/share/cargo/registry/serde-1.0.210/src/integer128.rs
/usr/share/cargo/registry/serde-1.0.210/src/lib.rs
/usr/share/cargo/registry/serde-1.0.210/src/macros.rs
/usr/share/cargo/registry/serde-1.0.210/src/private
/usr/share/cargo/registry/serde-1.0.210/src/private/de.rs
/usr/share/cargo/registry/serde-1.0.210/src/private/doc.rs
/usr/share/cargo/registry/serde-1.0.210/src/private/mod.rs
/usr/share/cargo/registry/serde-1.0.210/src/private/ser.rs
/usr/share/cargo/registry/serde-1.0.210/src/ser
/usr/share/cargo/registry/serde-1.0.210/src/ser/fmt.rs
/usr/share/cargo/registry/serde-1.0.210/src/ser/impls.rs
/usr/share/cargo/registry/serde-1.0.210/src/ser/impossible.rs
/usr/share/cargo/registry/serde-1.0.210/src/ser/mod.rs
/usr/share/cargo/registry/serde-1.0.210/src/std_error.rs
/usr/share/cargo/registry/serde-1.0.225
/usr/share/cargo/registry/serde-1.0.225/.cargo-checksum.json
/usr/share/cargo/registry/serde-1.0.225/Cargo.toml
/usr/share/cargo/registry/serde-1.0.225/LICENSE-APACHE
/usr/share/cargo/registry/serde-1.0.225/LICENSE-MIT
/usr/share/cargo/registry/serde-1.0.225/README.md
/usr/share/cargo/registry/serde-1.0.225/build.rs
/usr/share/cargo/registry/serde-1.0.225/crates-io.md
/usr/share/cargo/registry/serde-1.0.225/src
/usr/share/cargo/registry/serde-1.0.225/src/integer128.rs
/usr/share/cargo/registry/serde-1.0.225/src/lib.rs
/usr/share/cargo/registry/serde-1.0.225/src/private
/usr/share/cargo/registry/serde-1.0.225/src/private/de.rs
/usr/share/cargo/registry/serde-1.0.225/src/private/mod.rs
/usr/share/cargo/registry/serde-1.0.225/src/private/ser.rs
```

</details>