### PR TITLE
POC of using cargo package for installation

### DIFF
--- a/colcon_cargo/package_augmentation/cargo.py
+++ b/colcon_cargo/package_augmentation/cargo.py
@@ -93,7 +93,8 @@ def extract_dependencies(package_name, content, path):
         )
     }
     return {
-        'build': depends | build_depends | dev_depends,
+         # REVERT, remove test dependency for false positive circular dep error
+        'build': depends | build_depends,
         'run': depends | build_depends,
     }
 

--- a/colcon_cargo/task/cargo/build.py
+++ b/colcon_cargo/task/cargo/build.py
@@ -1,9 +1,11 @@
 # Copyright 2018 Easymov Robotics
 # Licensed under the Apache License, Version 2.0
 
+import glob
 import json
 from pathlib import Path
 import shutil
+import tarfile
 
 from colcon_cargo.task.cargo import CARGO_EXECUTABLE
 from colcon_core.environment import create_environment_scripts
@@ -100,8 +102,17 @@ class CargoBuildTask(TaskExtensionPoint):
 
         if self._has_libraries(metadata, pkg.name):
             self.progress('package')
-            await self._install_package(
-                metadata['packages'][0]['version'], env)
+            cmd = self._package_cmd(cargo_args)
+            rc = await run(
+                self.context, cmd, cwd=pkg.path, env=env)
+            if rc and rc.returncode:
+                return rc.returncode
+            # Now we extract the crate to have its source available locally for patching
+            # TODO(luca) check whether we really need this or we can just use the .crate file
+            # TODO(luca) remove indexing, check for return values etc.
+            crate_path = glob.glob(args.build_base + '/package/*.crate')[0]
+            crate_archive = tarfile.open(crate_path)
+            crate_archive.extractall(args.install_base + '/share/' + pkg.name + '/rust/')
 
         if not skip_hook_creation:
             create_environment_scripts(
@@ -132,6 +143,24 @@ class CargoBuildTask(TaskExtensionPoint):
             for arg in cargo_args
         ):
             cmd += ['--profile', 'dev']
+        return cmd + cargo_args
+
+    def _package_cmd(self, cargo_args):
+        args = self.context.args
+        pkg = self.context.pkg
+        # Verifying extracts and builds which could take considerable time.
+        # Instead, we skip verification and manually extract the tarfile to make it discoverable
+        # We will create the package in the build dir then extract it in the install dir
+        cmd = [
+            CARGO_EXECUTABLE,
+            'package',
+            '--quiet',
+            '--allow-dirty',
+            '--no-metadata',
+            '--no-verify',
+            '--package', pkg.name,
+            '--target-dir', args.build_base,
+        ]
         return cmd + cargo_args
 
     # Overridden by colcon-ros-cargo
@@ -227,59 +256,3 @@ class CargoBuildTask(TaskExtensionPoint):
         # If no library target exists in the whole package, then skip extracted
         # crate installation because it isn't useful.
         return False
-
-    # Determine what files would be part of a packaged crate
-    async def _get_crate_contents(self, env):
-        pkg = self.context.pkg
-        cmd = [
-            CARGO_EXECUTABLE,
-            'package',
-            '--list',
-            '--allow-dirty',
-            '--quiet',
-            '--package', pkg.name,
-        ]
-
-        rc = await run(
-            self.context,
-            cmd,
-            cwd=self.context.pkg.path,
-            capture_output=True,
-            env=env
-        )
-        if rc is None or rc.returncode != 0:
-            raise RuntimeError(
-                "Could not inspect package using 'cargo package'"
-            )
-
-        if rc.stdout is None:
-            raise RuntimeError(
-                "Failed to capture stdout from 'cargo package'"
-            )
-
-        contents = set(rc.stdout.decode().splitlines())
-        contents.difference_update({
-            # Ignore stuff that we wouldn't want to copy
-            '',
-            None,
-            'Cargo.lock',
-            'Cargo.toml.orig',
-            '.cargo_vcs_info.json',
-        })
-        return contents
-
-    async def _install_package(self, version, env):
-        contents = await self._get_crate_contents(env)
-        crate_path = Path(
-            'share', 'cargo', 'registry', f'{self.context.pkg.name}-{version}')
-
-        for file in contents:
-            dst = crate_path / file
-            install(self.context.args, file, dst)
-
-        # Cargo "directory sources" require a checksum file to be included in
-        # the package metadata (though it need not list all of the files).
-        create_file(
-            self.context.args,
-            crate_path / '.cargo-checksum.json',
-            content='{"files":{},"package":""}\n')


### PR DESCRIPTION
This PR targets #67  and illustrates the idea I have been toying with about using `cargo package` to install libraries through `colcon-cargo`.
It's just a POC to facilitate discussion, ideally we can at least be smarter with caching / remove duplicated work and rework install folder structures.
The proposed implementation in #67 uses `cargo package --list` to get a list of files that would be installed then uses the output to copy files from the package's source directory into the install space.
This however, is not sufficient for packages that are in a cargo workspace, since `cargo package` actually performs a series of operations to the `Cargo.toml` to, for example, remove relative path dependencies, resolve workspace dependencies etc. (point 1 and some of point 2 [here](https://doc.rust-lang.org/cargo/commands/cargo-package.html#description)).
This shows in the fact that what we actually install in #67 doesn't compile if applied to a more complex package.

I came up with a "simple" test case for both #67 and this PR to show the difference.

## Setup

Create a workspace and bring a [custom tokio](https://github.com/luca-della-vedova/tokio) (where I [just added a public `hello_world` function](https://github.com/luca-della-vedova/tokio/commit/55b0ef2defbf8e25a53ab17d2e5b55592cf9ec43)) and a [POC crate](https://github.com/luca-della-vedova/cargo_custom_tokio_package) that tests it (has a library and an executable that call the new tokio function).

```bash
mkdir -p tokio_ws/src
cd tokio_ws/src
git clone https://github.com/luca-della-vedova/tokio
git clone https://github.com/luca-della-vedova/cargo_custom_tokio_package
```

## Test with #67 

Remove `dev_depends` from [here](https://github.com/colcon/colcon-cargo/blob/518a4f90d7de33d685cfba32a45fb4cb3aa08950/colcon_cargo/package_augmentation/cargo.py#L96) as done in this PR to avoid circular dependency errors 

```bash
# TODO Install or checkout the colcon-cargo branch in #67
cd ~/tokio_ws
rm -rf build install log
colcon build --packages-up-to tokio
cd install/tokio/share/cargo/registry/tokio-1.48.0
cargo build
```

Since the tokio Cargo.toml has one of these ["workspace inheritances"](https://github.com/luca-della-vedova/tokio/blob/55b0ef2defbf8e25a53ab17d2e5b55592cf9ec43/tokio/Cargo.toml#L188-L189), the build will actually fail, making the crate effectively non functional:

```
:~/tokio_ws/install/tokio/share/cargo/registry/tokio-1.48.0$ cargo build
error: failed to parse manifest at `~/tokio_ws/install/tokio/share/cargo/registry/tokio-1.48.0/Cargo.toml`

Caused by:
  error inheriting `lints` from workspace root manifest's `workspace.lints`

Caused by:
  failed to find a workspace root
```

The snippet is preserved when copying the file and cannot be resolved since the file is copied to a different location and its workspace's `Cargo.toml` is not in its parent folder anymore.

```
[lints]
workspace = true
```

## Test with this branch

```bash
# TODO Install this PR's colcon-cargo version
cd ~/tokio_ws
rm -rf build install log
colcon build --packages-up-to tokio
cd install/tokio/share/tokio/rust/tokio-1.48.0 # I just put it here to follow what we do with other rust packages, happy to bikeshed
cargo build
```

You will see that the package builds correctly, meaning the workspace migration was done by Cargo.
Inspecting the installed Cargo.toml, we can see that the linter configuration was migrated to a standalone configuration that does not reference the workspace's `Cargo.toml`:

```
[lints.rust.unexpected_cfgs]
level = "warn"
priority = 0
check-cfg = [
    "cfg(fuzzing)",
    "cfg(loom)",
    "cfg(mio_unsupported_force_poll_poll)",
    "cfg(tokio_allow_from_blocking_fd)",
    "cfg(tokio_internal_mt_counters)",
    "cfg(tokio_no_parking_lot)",
    "cfg(tokio_no_tuning_tests)",
    "cfg(tokio_unstable)",
    'cfg(target_os, values("cygwin"))',
]
```

Additionally, if now you build the sample package:

```bash
# TODO Install this PR's colcon-cargo version
cd ~/tokio_ws
rm -rf build install log
colcon build --packages-up-to cargo_custom_tokio_package
```

It will build successfully and running it will work, meaning the [hardcoded patch](https://github.com/luca-della-vedova/cargo_custom_tokio_package/blob/main/.cargo/config.toml) correctly resolved to a tokio with the custom function:

```bash
$ install/cargo_custom_tokio_package/bin/cargo_custom_tokio_package 
HELLO THERE
```

## Conclusion

* Just copying files is not sufficient, `cargo package` does a lot more for non-toy projects. I demonstrated this with tokio but most major projects out there have workspace dependencies that would make them non functional (i.e. [serde](https://github.com/serde-rs/serde/blob/f7fc3e0d676486236edf3bc3ebe0b9e9a552f81a/serde_derive/Cargo.toml#L25-L28)).
* This approach should make packages functional and use a similar approach to what we currently do in `colcon-ros-cargo` / message generation. Patching is hardcoded but left as future work (perhaps through pallet patcher?)
* There are rough edges, specifically I wonder if `cargo package` _always_ builds a package even if it was unchanged, since I see that install times are quite significant even when no changes are made.